### PR TITLE
fix the issue #29:MS-OXCFXICS_R1392 doesn't check "Fixed Position" requirement for rowid in Recipient table

### DIFF
--- a/ExchangeMAPI/Source/MS-OXCFXICS/Adapter/CaptureCode.cs
+++ b/ExchangeMAPI/Source/MS-OXCFXICS/Adapter/CaptureCode.cs
@@ -3840,7 +3840,9 @@ namespace Microsoft.Protocols.TestSuites.MS_OXCFXICS
                         Site.Log.Add(LogEntryKind.Debug, "Verify MS-OXCFXICS_R1392");
 
                         // Verify MS-OXCFXICS requirement: MS-OXCFXICS_R1392
-                        bool isVerifyR1392 = isVerifyR1391;
+                        // 0x3000 is the property id of PidTagRowid according [MS-OXPROPS].
+                        // If the position of PidTagRowid is first, R1392 will be verified. 
+                        bool isVerifyR1392 = recipient.PropList.PropValues[0].PropInfo.PropID == 0x3000;
                         Site.CaptureRequirementIfIsTrue(
                             isVerifyR1392,
                             1392,

--- a/FileSyncandWOPI/Docs/FssWopiTestSuiteDeploymentGuide.md
+++ b/FileSyncandWOPI/Docs/FssWopiTestSuiteDeploymentGuide.md
@@ -72,6 +72,7 @@ following versions of SharePoint Server:
 -   Microsoft SharePoint Server 2013 Service Pack 1 (SP1)
 -   Microsoft SharePoint Server 2016
 -   Microsoft SharePoint Server 2019
+
 The following table describes the required server roles for a
 test suite deployment with Microsoft implementation.
 


### PR DESCRIPTION
Fix issue #29:MS-OXCFXICS_R1392 doesn't check "Fixed Position" requirement for rowid in Recipient table