### PR TITLE
MS-ONESTORE - rgFileNodes of >1th FileNodeListFragments were not parsed correctly to RootFileNodeList

### DIFF
--- a/FileSyncandWOPI/Source/MS-ONESTORE/Adapter/Stack/FileStructrue/RootFileNodeList.cs
+++ b/FileSyncandWOPI/Source/MS-ONESTORE/Adapter/Stack/FileStructrue/RootFileNodeList.cs
@@ -54,7 +54,7 @@
                 nextFragment.DoDeserializeFromByteArray(byteArray, (int)nextFragmentRef.Stp);
                 nextFragmentRef = nextFragment.nextFragment;
                 this.FileNodeListFragments.Add(nextFragment);
-                this.FileNodeSequence.AddRange(fragment.rgFileNodes.Where(f => f.FileNodeID != FileNodeIDValues.ChunkTerminatorFND).ToArray());
+                this.FileNodeSequence.AddRange(nextFragment.rgFileNodes.Where(f => f.FileNodeID != FileNodeIDValues.ChunkTerminatorFND).ToArray());
             }
 
             FileNode[] objectSpaceManifestListReferences = this.FileNodeSequence.Where(obj => obj.FileNodeID == FileNodeIDValues.ObjectSpaceManifestListReferenceFND).ToArray();


### PR DESCRIPTION
Regarding the MS-ONESTORE Adapter,
i believe there is an error in the deserializer of the `RootFileNodeList` object.
(FileSyncandWOPI/Source/MS-ONESTORE/Adapter/Stack/FileStructrue/RootFileNodeList.cs)


In the respective Method, line 49, the `rgFileNodes` of the first `FileNodeListFragment` are added to the `FileNodeSequence` list.

In the while loop below the `FileNodeListFragment` tree is parsed (l. 51--58)
Each following `FileNodeListFragments` is parsed and added to the list of `FileNodeListFragments` in the `RootFileNodeList` object.

Currently, in this while loop, the `rgFileNodes` of the first `FileNodeListFragment` is added to the `FileNodeSequence` list as often as there are `FileNodeListFragment` tree nodes. 

So the `FileNodeSequence` contains duplicated sections of the  first `FileNodeListFragment`, however, the `rgFileNodes` of subsequentially `FileNodeListFragments` are not added to the `FileNodeSequence` list .

Studying the Specification of MS-ONESTORE section 2.4, i may quote:

_For storage purposes a file node list can be divided into one or more FileNodeListFragment structures (section 2.4.1). Each fragment can specify whether there are more fragments in the list and the location of the next fragment. **Each fragment specifies a sub-sequence of FileNode structures** from the file node list._

Therefore, i come to the conclusion, that in line 57, calling `fragment` in `this.FileNodeSequence.AddRange(fragment.rgFileNodes ....` is incorrect.
Instead, i believe, the intention was:
`this.FileNodeSequence.AddRange(nextFragment.rgFileNodes ... `


Edit:
A similar parsing structure  can be found in the `ObjectSpaceManifestList.cs` object (line 43--55).
there, `fragment` is only parsed once, and in the while loop, the dynamic `nextFragment` is parsed, resulting in no (intentional) duplicate sequences in the FileNodeSequence.