### PR TITLE
Correct deserialize of ObjectSpaceObjectPropSet

### DIFF
--- a/FileSyncandWOPI/Source/Common/ONESTORE/OtherStructures/ObjectSpaceObjectPropSet.cs
+++ b/FileSyncandWOPI/Source/Common/ONESTORE/OtherStructures/ObjectSpaceObjectPropSet.cs
@@ -46,13 +46,13 @@
                 len = this.OSIDs.DoDeserializeFromByteArray(byteArray, index);
                 index += len;
 
-				if (this.OSIDs.Header.ExtendedStreamsPresent == 1)
-				{
-					this.ContextIDs = new ObjectSpaceObjectStreamOfContextIDs();
-					len = this.ContextIDs.DoDeserializeFromByteArray(byteArray, index);
-					index += len;
-				}
-			}
+                if (this.OSIDs.Header.ExtendedStreamsPresent == 1)
+                {
+                    this.ContextIDs = new ObjectSpaceObjectStreamOfContextIDs();
+                    len = this.ContextIDs.DoDeserializeFromByteArray(byteArray, index);
+                    index += len;
+                }
+            }
             this.Body = new PropertySet();
             len = this.Body.DoDeserializeFromByteArray(byteArray, index);
             index += len;

--- a/FileSyncandWOPI/Source/Common/ONESTORE/OtherStructures/ObjectSpaceObjectPropSet.cs
+++ b/FileSyncandWOPI/Source/Common/ONESTORE/OtherStructures/ObjectSpaceObjectPropSet.cs
@@ -45,13 +45,14 @@
                 this.OSIDs = new ObjectSpaceObjectStreamOfOSIDs();
                 len = this.OSIDs.DoDeserializeFromByteArray(byteArray, index);
                 index += len;
-            }
-            if (this.OIDs.Header.OsidStreamNotPresent == 0 && this.OIDs.Header.ExtendedStreamsPresent == 1)
-            {
-                this.ContextIDs = new ObjectSpaceObjectStreamOfContextIDs();
-                len = this.ContextIDs.DoDeserializeFromByteArray(byteArray, index);
-                index += len;
-            }
+
+				if (this.OSIDs.Header.ExtendedStreamsPresent == 1)
+				{
+					this.ContextIDs = new ObjectSpaceObjectStreamOfContextIDs();
+					len = this.ContextIDs.DoDeserializeFromByteArray(byteArray, index);
+					index += len;
+				}
+			}
             this.Body = new PropertySet();
             len = this.Body.DoDeserializeFromByteArray(byteArray, index);
             index += len;


### PR DESCRIPTION
According to [MS-ONESTORE], section 2.6.1, the optional field ContextIDs is
only present if OSIDs is present and the OSIDs.header.ExtendedStreamsPresent
field is true.

This commit nests the check whether there is a ContextIDs field present
into the branch where the optional field OSIDs is present.
If OSIDs is not present, ContextIDs cannot be present as well according
to the specification.

Please see the issue #45 for discussion.