### PR TITLE
Added R17802021Enabled in 2010, 2013, and 2016. Resolve the .one file parsing failure downloaded from OneDrive .

### DIFF
--- a/FileSyncandWOPI/Source/SharedTestSuite/SharedAdapter/Stack/ONESTORE/MSOneStorePackage.cs
+++ b/FileSyncandWOPI/Source/SharedTestSuite/SharedAdapter/Stack/ONESTORE/MSOneStorePackage.cs
@@ -119,10 +119,18 @@
         public static HeaderCell CreateInstance(ObjectGroupDataElementData objectElement)
         {
             HeaderCell instance = new HeaderCell();
-            instance.ObjectDeclaration = objectElement.ObjectGroupDeclarations.ObjectDeclarationList[0];
-            ObjectGroupObjectData objectData = objectElement.ObjectGroupData.ObjectGroupObjectDataList[0];
-            instance.ObjectData = new ObjectSpaceObjectPropSet();
-            instance.ObjectData.DoDeserializeFromByteArray(objectData.Data.Content.ToArray(), 0);
+
+            for (int i = 0; i < objectElement.ObjectGroupDeclarations.ObjectDeclarationList.Count; i++)
+            {
+                if (objectElement.ObjectGroupDeclarations.ObjectDeclarationList[i].ObjectPartitionID != null && objectElement.ObjectGroupDeclarations.ObjectDeclarationList[i].ObjectPartitionID.DecodedValue == 1)
+                {
+                    instance.ObjectDeclaration = objectElement.ObjectGroupDeclarations.ObjectDeclarationList[i];
+                    ObjectGroupObjectData objectData = objectElement.ObjectGroupData.ObjectGroupObjectDataList[i];
+                    instance.ObjectData = new ObjectSpaceObjectPropSet();
+                    instance.ObjectData.DoDeserializeFromByteArray(objectData.Data.Content.ToArray(), 0);
+                    break;
+                }
+            }
 
             return instance;
         }

--- a/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2010_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2010_SHOULDMAY.deployment.ptfconfig
@@ -26,6 +26,8 @@
     <Property name="R19701Enabled" value="false"/>
     <!-- Set R17602Enabled to true to verify that the server returns error code 0x80131600 for the pound sign (#) truncated file name does not exist on the server. Set R17602Enabled to false to disable this requirement. -->
     <Property name="R17602Enabled" value="true"/>
+	<!-- Set R1960102Enabled to true to verify that the server returns error code 0x80131600 for invalid characters . Set R19602Enabled to false to disable this requirement. -->
+    <Property name="R1960102Enabled" value="false"/>
     <!-- Set R19602Enabled to true to verify that the server returns error code 0x81070970 for invalid characters . Set R19602Enabled to false to disable this requirement. -->
     <Property name="R19602Enabled" value="false"/>
     <!-- Set R197Enabled to true to verify that the server truncates all characters after the first "#" in the file name. Set R197Enabled to false to disable this requirement. -->

--- a/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2013_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2013_SHOULDMAY.deployment.ptfconfig
@@ -26,6 +26,8 @@
     <Property name="R19701Enabled" value="false"/>
     <!-- Set R17602Enabled to true to verify that the server returns error code 0x80131600 for the pound sign (#) truncated file name does not exist on the server. Set R17602Enabled to false to disable this requirement. -->
     <Property name="R17602Enabled" value="true"/>
+	<!-- Set R1960102Enabled to true to verify that the server returns error code 0x80131600 for invalid characters . Set R19602Enabled to false to disable this requirement. -->
+    <Property name="R1960102Enabled" value="false"/>
     <!-- Set R19602Enabled to true to verify that the server returns error code 0x81070970 for invalid characters . Set R19602Enabled to false to disable this requirement. -->
     <Property name="R19602Enabled" value="false"/>
     <!-- Set R197Enabled to true to verify that the server truncates all characters after the first "#" in the file name. Set R197Enabled to false to disable this requirement. -->

--- a/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2016_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2016_SHOULDMAY.deployment.ptfconfig
@@ -28,6 +28,8 @@
     <Property name="R17602Enabled" value="true"/>
     <!-- Set R19602Enabled to true to verify that the server returns error code 0x81070970 for invalid characters . Set R19602Enabled to false to disable this requirement. -->
     <Property name="R19602Enabled" value="false"/>
+	<!-- Set R1960102Enabled to true to verify that the server returns error code 0x80131600 for invalid characters . Set R19602Enabled to false to disable this requirement. -->
+    <Property name="R1960102Enabled" value="false"/> 
     <!-- Set R197Enabled to true to verify that the server truncates all characters after the first "#" in the file name. Set R197Enabled to false to disable this requirement. -->
     <Property name="R197Enabled" value="true"/>
     <!-- Set R198Enabled to true to verify that the server will return no error code for deleting current version of the file. Set R198Enabled to false to disable this requirement. -->


### PR DESCRIPTION
Added R17802021Enabled in 2010, 2013, and 2016. Resolve the .one file parsing failure downloaded from OneDrive .